### PR TITLE
fix: make sure nginx includes appear first

### DIFF
--- a/ngx_event_maxconn.c
+++ b/ngx_event_maxconn.c
@@ -1,11 +1,11 @@
 /* (C) 2015 Cybozu.  All rights reserved. */
 
-#include <assert.h>
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_event.h>
 #include <ngx_event_connect.h>
 #include <ngx_event_maxconn.h>
+#include <assert.h>
 
 
 #define NGX_EVENT_MAXCONN_BUCKET_SIZE 257


### PR DESCRIPTION
This fixes the include statements in `ngx_event_maxconn.c`.

As per the nginx [development spec](http://nginx.org/en/docs/dev/development_guide.html#include_files), nginx includes must appear at the beginning of every nginx file. Up until recently, there were no obvious issues with the current include order, but with changes made in https://hg.nginx.org/nginx/rev/cfe1284e5d1d compilation will fail with the following error:

```
src/event/ngx_event_udp.h:38:27: error: field ‘pkt6’ has incomplete type
     struct in6_pktinfo    pkt6;
                           ^~~~
objs/Makefile:1443: recipe for target 'objs/addon/nginx-maxconn-module/ngx_event_maxconn.o' failed
```

Ref: https://trac.nginx.org/nginx/ticket/2312